### PR TITLE
Revert "chore(deps:dockerfile-bot): bump python from 3.12.7-slim to 3.13.0-slim in /discord"

### DIFF
--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.0-slim
+FROM python:3.12.7-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Reverts act-kithub/KITHUBSys#78

Due to PEP 594, audioop was removed from the standard library modules in Python 3.13, making pycord's player.py incompatible.