### PR TITLE
develop

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -24,6 +24,9 @@ services:
         condition: service_completed_successfully
     networks:
       - db
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
 
   db:
     image: postgres:16
@@ -56,6 +59,9 @@ services:
         condition: service_healthy
     networks:
       - db
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
 
 volumes:
   pg_data:

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -3,9 +3,6 @@ FROM python:3.12.9-slim
 # set workdir
 WORKDIR /app
 
-# set dns
-RUN echo "nameserver 8.8.8.8
-nameserver 8.8.4.4" > /etc/resolv.conf
 
 RUN apt update && \
     apt upgrade -y && \

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -2,10 +2,6 @@ FROM python:3.12.9-slim
 
 WORKDIR /app
 
-# set dns
-RUN echo "nameserver 8.8.8.8
-nameserver 8.8.4.4" > /etc/resolv.conf
-
 RUN apt update && \
     apt upgrade -y && \
     apt install -y build-essential git nano curl \


### PR DESCRIPTION
- **(deps:pip): Bump alembic from 1.14.0 to 1.14.1**
- **(deps:pip): Bump pydantic from 2.10.5 to 2.10.6**
- **(deps:pip): Bump isort from 5.13.2 to 6.0.0**
- **(deps:pip): Bump black from 24.10.0 to 25.1.0**
- **(deps:pip): Bump pytz from 2024.2 to 2025.1**
- **(deps:pip): Bump sqlalchemy from 2.0.37 to 2.0.38**
- **(deps:dockerfile-bot): Bump python in /discord**
- **(deps:dockerfile-db): Bump python from 3.12.7-slim to 3.13.2-slim in /db**
- **fix: pythonバージョンを下げる**
- **(deps:pip): Bump flake8 from 7.1.1 to 7.1.2**
- **(deps:pip): Bump mypy from 1.14.1 to 1.15.0**
- **(deps:pip): Bump sentry-sdk from 2.20.0 to 2.22.0**
- **fix: dns設定をオーバーライド**
- **fix: dns設定をオーバーライド**
