### PR TITLE
develop

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -24,9 +24,6 @@ services:
         condition: service_completed_successfully
     networks:
       - db
-    dns:
-      - 8.8.8.8
-      - 8.8.4.4
 
   db:
     image: postgres:16
@@ -59,9 +56,6 @@ services:
         condition: service_healthy
     networks:
       - db
-    dns:
-      - 8.8.8.8
-      - 8.8.4.4
 
 volumes:
   pg_data:


### PR DESCRIPTION
- **(deps:pip): Bump alembic from 1.14.0 to 1.14.1**
- **(deps:pip): Bump pydantic from 2.10.5 to 2.10.6**
- **(deps:pip): Bump isort from 5.13.2 to 6.0.0**
- **(deps:pip): Bump black from 24.10.0 to 25.1.0**
- **(deps:pip): Bump pytz from 2024.2 to 2025.1**
- **(deps:pip): Bump sqlalchemy from 2.0.37 to 2.0.38**
- **(deps:dockerfile-bot): Bump python in /discord**
- **(deps:dockerfile-db): Bump python from 3.12.7-slim to 3.13.2-slim in /db**
- **fix: pythonバージョンを下げる**
- **(deps:pip): Bump flake8 from 7.1.1 to 7.1.2**
- **(deps:pip): Bump mypy from 1.14.1 to 1.15.0**
- **(deps:pip): Bump sentry-sdk from 2.20.0 to 2.22.0**
- **fix: dns設定をオーバーライド**
- **fix: dns設定をオーバーライド**
- **fix: host側iptablesの問題だった**
