### PR TITLE
feat: デプロイをGHAビルド + ghcr.io経由のイメージpull方式に変更

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
 .idea
 .venv
 .git
+.github
+.claude
+.local
 node_modules
+envs
+pgadmin
+**/__pycache__

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             trap 'docker logout ghcr.io' EXIT
             cd ${{github.event.repository.name}}
+            git diff --quiet && git diff --cached --quiet
             git fetch origin
             git checkout -B main ${{ github.sha }}
             export IMAGE_TAG=${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,46 @@ on:
   push:
     branches: [ main ]
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - service: discord
+            dockerfile: discord/Dockerfile
+          - service: db-migrator
+            dockerfile: db/Dockerfile
     steps:
       - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:latest
+            ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: read
+    steps:
       - name: Deploy
         uses: appleboy/ssh-action@master
         with:
@@ -17,6 +53,8 @@ jobs:
           port: ${{secrets.SSH_PORT}}
           command_timeout: 30m
           script: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             cd ${{github.event.repository.name}}
             git pull origin main
             make deploy:prod ENV=prod
+            docker logout ghcr.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy
 on:
   push:
     branches: [ main ]
+concurrency:
+  group: deploy
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,8 +56,10 @@ jobs:
           port: ${{secrets.SSH_PORT}}
           command_timeout: 30m
           script: |
+            set -e
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            trap 'docker logout ghcr.io' EXIT
             cd ${{github.event.repository.name}}
             git pull origin main
+            export IMAGE_TAG=${{ github.sha }}
             make deploy:prod ENV=prod
-            docker logout ghcr.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             trap 'docker logout ghcr.io' EXIT
             cd ${{github.event.repository.name}}
-            git pull origin main
+            git fetch origin
+            git checkout -B main ${{ github.sha }}
             export IMAGE_TAG=${{ github.sha }}
             make deploy:prod ENV=prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,8 @@ jobs:
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             trap 'docker logout ghcr.io' EXIT
             cd ${{github.event.repository.name}}
-            git diff --quiet && git diff --cached --quiet
+            git diff --quiet
+            git diff --cached --quiet
             git fetch origin
             git checkout -B main ${{ github.sha }}
             export IMAGE_TAG=${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,13 @@ pr\:create:
 	gh pr create --base main --head $(shell git branch --show-current)
 	gh pr view --web
 
+pull:
+	docker compose -f $(COMPOSE_YML) pull
+
 deploy\:prod:
-	make build ENV=prod
-	make reload ENV=prod
+	make pull ENV=prod
+	docker compose -f compose.prod.yml down
+	docker compose -f compose.prod.yml up -d
 
 poetry\:install:
 	pip install poetry
@@ -80,4 +84,4 @@ envs\:setup:
 	cp envs/db.env.example envs/db.env
 	cp envs/sentry.env.example envs/sentry.env
 
-PHONY: build up down logs ps pr\:create deploy\:prod poetry\:install poetry\:add poetry\:lock poetry\:update poetry\:reset dev\:setup db\:revision\:create db\:migrate envs\:init
+PHONY: build up down logs ps pull pr\:create deploy\:prod poetry\:install poetry\:add poetry\:lock poetry\:update poetry\:reset dev\:setup db\:revision\:create db\:migrate envs\:init

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,11 +1,6 @@
 services:
   discord:
-    build:
-      context: .
-      dockerfile: discord/Dockerfile
-    volumes:
-      - ./discord:/app
-      - ./db:/app/db
+    image: ghcr.io/act-kithub/kithubsys/discord:latest
     env_file:
       - ./envs/discord.env
       - ./envs/db.env
@@ -43,12 +38,8 @@ services:
       - db
 
   db-migrator:
-    build:
-      context: .
-      dockerfile: ./db/Dockerfile
+    image: ghcr.io/act-kithub/kithubsys/db-migrator:latest
     tty: true
-    volumes:
-      - ./db:/app
     env_file:
       - ./envs/db.env
     depends_on:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   discord:
-    image: ghcr.io/act-kithub/kithubsys/discord:latest
+    image: ghcr.io/act-kithub/kithubsys/discord:${IMAGE_TAG:-latest}
     env_file:
       - ./envs/discord.env
       - ./envs/db.env
@@ -38,7 +38,7 @@ services:
       - db
 
   db-migrator:
-    image: ghcr.io/act-kithub/kithubsys/db-migrator:latest
+    image: ghcr.io/act-kithub/kithubsys/db-migrator:${IMAGE_TAG:-latest}
     tty: true
     env_file:
       - ./envs/db.env

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -14,4 +14,7 @@ COPY ./db/poetry.lock ./db/pyproject.toml ./db/Makefile /app/
 RUN poetry config virtualenvs.create false
 RUN make poetry:install
 
+# bake application code into the image (dev: volume mountで上書きされる)
+COPY ./db /app
+
 CMD ["/bin/bash", "-c", "alembic upgrade head"]

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -16,4 +16,10 @@ RUN make poetry:install
 # add poetry files for symlinks
 COPY ./pyproject.toml ./poetry.lock /
 
+# bake application code into the image (dev: volume mountで上書きされる)
+COPY ./discord /app
+# discord/db は ../db へのsymlinkのため、実体をCOPYし直す
+RUN rm -f /app/db
+COPY ./db /app/db
+
 CMD ["/app/bot.sh"]


### PR DESCRIPTION
## 概要

デプロイサーバーが非力でDocker buildに時間がかかるため、ビルドをGitHub Actionsに移し、サーバー側はghcr.ioからイメージをpullして再起動するだけの構成に変更する。

## やったこと

### GHA（deploy.yml）
- `build` job を追加: discord / db-migrator の2イメージをmatrixでビルドし ghcr.io へ push
  - タグ: `ghcr.io/act-kithub/kithubsys/<service>:latest` と `:<commit sha>`（`:sha` はロールバック用）
  - `cache-from/to: type=gha` でレイヤーキャッシュを利用
- `deploy` job は `needs: build` で直列化。SSHスクリプト内で `GITHUB_TOKEN` を使って `docker login ghcr.io` → `make deploy:prod` → `docker logout`
  - サーバー側にPAT等の追加シークレット設置は不要

### イメージへのコード焼き込み
- discord/Dockerfile: 依存インストール後に `COPY ./discord /app`。`discord/db` は `../db` へのsymlinkのため、除去して実体を `COPY ./db /app/db`
- db/Dockerfile: `COPY ./db /app`
- dev環境はvolumeマウントが焼き込みコードを上書きするため従来どおり動作

### compose / Makefile
- compose.prod.yml: `build:` とコードのvolumeマウントを撤去し `image:`（ghcr.io参照）に変更
- Makefile: `pull` ターゲットを追加し、`deploy:prod` を「pull → down → up -d」に変更（従来は build → down → up -d）

### その他
- .dockerignore にビルドコンテキスト外のディレクトリ（.github / .claude / .local / envs / pgadmin / __pycache__）を追加

## やらなかったこと

- `make db:migrate ENV=prod` / `db:revision:create ENV=prod` の対応（内部で `compose build` するため、build定義のなくなったprod composeでは失敗する。デプロイでは db-migrator が depends_on で実行されるため運用影響なし。必要になれば別途対応）
- dev環境のビルドフロー変更（従来どおりローカルビルド）

## 影響範囲

- 本番デプロイフロー全体（mainへのpush時のGHA）
- 本番のコンテナ起動構成（コードがvolumeマウント→イメージ内蔵に変わる）

## テスト方法

- `docker compose -f compose.prod.yml config` / `compose.dev.yml config` 通過を確認済み
- `actionlint` 通過を確認済み
- COPY層のみのテストビルドで、bot.sh の実行権限維持・symlinkの実体化・alembic.ini / migrations の配置を確認済み
- 本番相当の確認はマージ後の初回デプロイで実施（build job成功 → ghcr.io へのpush → サーバーでのpull起動）

## マージ後の確認事項

- [ ] 初回デプロイ後、ghcr.io のパッケージ visibility を確認（リポジトリはpublicのためpublic継承想定。privateになっていてもdeploy jobのdocker loginで動作はする）

## チェックリスト

- [x] compose config 通過
- [x] actionlint 通過

https://claude.ai/code/session_01QAJGNVYDiLgpVXjSEiTg9Q