### PR TITLE
chore: develop廃止に伴うdependabot刷新 + release公開トリガーのCD化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,9 @@ updates:
       - "automated pr"
     assignees:
       - "ukwhatn"
+    # github-actions/dockerはsemver別cooldown非対応のためdefault-daysのみ
     cooldown:
       default-days: 3
-      semver-patch-days: 1
     groups:
       github-actions-all:
         applies-to: version-updates
@@ -26,10 +26,8 @@ updates:
           - "*"
 
   - package-ecosystem: "pip"
-    directories:
-      - "/"
-      - "/discord"
-      - "/db"
+    # discord/・db/のpyproject/poetry.lockはrootへのsymlinkのため"/"のみで全依存をカバー
+    directory: "/"
     schedule:
       interval: "weekly"
     versioning-strategy: increase-if-necessary
@@ -72,9 +70,9 @@ updates:
       - "automated pr"
     assignees:
       - "ukwhatn"
+    # github-actions/dockerはsemver別cooldown非対応のためdefault-daysのみ
     cooldown:
       default-days: 3
-      semver-patch-days: 1
     groups:
       docker-all:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
-    # pyprojectのpython = "3.12.*" 制約と揃えるため、patch更新のみ許可
+    # pyprojectのpython = "3.12.*" 制約と揃えるため、version updateはpatchのみ許可（security updateはignore対象外）
     ignore:
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -55,7 +55,7 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
-    # pyprojectのpython = "3.12.*" 制約と揃えるため、patch更新のみ許可
+    # pyprojectのpython = "3.12.*" 制約と揃えるため、version updateはpatchのみ許可（security updateはignore対象外）
     ignore:
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    target-branch: "develop"
+      interval: "weekly"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "(deps:github-actions)"
     labels:
@@ -12,15 +12,28 @@ updates:
       - "automated pr"
     assignees:
       - "ukwhatn"
-    reviewers:
-      - "ukwhatn"
+    cooldown:
+      default-days: 3
+      semver-patch-days: 1
+    groups:
+      github-actions-all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+      - "/discord"
+      - "/db"
     schedule:
-      interval: "daily"
-    target-branch: "develop"
+      interval: "weekly"
     versioning-strategy: increase-if-necessary
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "(deps:pip)"
     labels:
@@ -28,35 +41,46 @@ updates:
       - "automated pr"
     assignees:
       - "ukwhatn"
-    reviewers:
-      - "ukwhatn"
+    cooldown:
+      default-days: 3
+      semver-patch-days: 1
+    groups:
+      pip-all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
-    directory: "/db"
+    directories:
+      - "/db"
+      - "/discord"
     schedule:
-      interval: "daily"
-    target-branch: "develop"
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    # pyprojectのpython = "3.12.*" 制約と揃えるため、patch更新のみ許可
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     commit-message:
-      prefix: "(deps:dockerfile-db)"
+      prefix: "(deps:docker)"
     labels:
       - "dependencies"
       - "automated pr"
     assignees:
       - "ukwhatn"
-    reviewers:
-      - "ukwhatn"
-
-  - package-ecosystem: "docker"
-    directory: "/discord"
-    schedule:
-      interval: "daily"
-    target-branch: "develop"
-    commit-message:
-      prefix: "(deps:dockerfile-bot)"
-    labels:
-      - "dependencies"
-      - "automated pr"
-    assignees:
-      - "ukwhatn"
-    reviewers:
-      - "ukwhatn"
+    cooldown:
+      default-days: 3
+      semver-patch-days: 1
+    groups:
+      docker-all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,10 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
+    # pyprojectのpython = "3.12.*" 制約と揃えるため、patch更新のみ許可
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     commit-message:
       prefix: "(deps:dockerfile-db)"
     labels:
@@ -51,6 +55,10 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
+    # pyprojectのpython = "3.12.*" 制約と揃えるため、patch更新のみ許可
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     commit-message:
       prefix: "(deps:dockerfile-bot)"
     labels:

--- a/.github/workflows/check_healthy.yml
+++ b/.github/workflows/check_healthy.yml
@@ -1,14 +1,22 @@
 name: Check services healthy
 
+# NOTE: pull_request_target は base ブランチのコードを checkout するため
+# PR の変更が検証されない（かつ head checkout に変えると secrets 窃取の危険がある）。
+# PR のコードを検証する CI として pull_request を使う。
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check_healthy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v7
@@ -18,46 +26,27 @@ jobs:
         make envs:setup
         sed -i 's/DISCORD_BOT_TOKEN=""/DISCORD_BOT_TOKEN="${{ secrets.CIBOT_TOKEN }}"/' envs/discord.env
 
-    - name: Build and start services
-      run: make up
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
-    - name: Wait for services to be ready and check health
+    - name: Build images (GHA layer cache)
+      uses: docker/bake-action@v7
+      with:
+        files: compose.dev.yml
+        load: true
+        set: |
+          *.cache-from=type=gha
+          *.cache-to=type=gha,mode=max
+
+    - name: Start services and wait until healthy
+      run: make up:ci
+
+    - name: Show service status and logs
+      if: always()
       run: |
-        max_retries=5
-        retry_interval=5
-        
-        for i in $(seq 1 $max_retries)
-        do
-          service_status=$(make ps)
-          if echo "$service_status" | grep -qiE "(starting|restarting|unhealthy)"; then
-            echo "Services are still initializing or unhealthy... (Attempt $i/$max_retries)"
-            echo "$service_status"
-            
-            if [ $i -eq $max_retries ]; then
-              echo "Services did not stabilize within the allocated time."
-              make logs:once
-              exit 1
-            fi
-            
-            sleep $retry_interval
-          else
-            echo "All services have stabilized!"
-            break
-          fi
-        done
-        
-        # Final health check
-        service_status=$(make ps)
-        if echo "$service_status" | grep -qiE "(unhealthy|exited|dead)"; then
-          echo "Some services are in an unhealthy state:"
-          echo "$service_status"
-          make logs:once
-          exit 1
-        else
-          echo "All services are healthy!"
-          echo "$service_status"
-          make logs:once
-        fi
+        make ps
+        make logs:once
 
     - name: Clean up
+      if: always()
       run: make down

--- a/.github/workflows/check_healthy.yml
+++ b/.github/workflows/check_healthy.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check_healthy:
     runs-on: ubuntu-latest
@@ -20,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Setup environment
       run: |
@@ -34,9 +39,13 @@ jobs:
       with:
         files: compose.dev.yml
         load: true
+        # GHA cacheのscopeはデフォルトで全ターゲット共通になり上書きし合うため、
+        # ターゲットごとに分離する
         set: |
-          *.cache-from=type=gha
-          *.cache-to=type=gha,mode=max
+          discord.cache-from=type=gha,scope=discord
+          discord.cache-to=type=gha,scope=discord,mode=max
+          db-migrator.cache-from=type=gha,scope=db-migrator
+          db-migrator.cache-to=type=gha,scope=db-migrator,mode=max
 
     - name: Start services and wait until healthy
       run: make up:ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ concurrency:
   cancel-in-progress: false
 jobs:
   build:
+    # pre-releaseではデプロイしない（deployはneedsで連動してskipされる）
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,6 +30,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sanitize release tag for image tag
+        id: meta
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: echo "release_tag=$(printf '%s' "$RELEASE_TAG" | tr -c 'a-zA-Z0-9_.-' '-')" >> "$GITHUB_OUTPUT"
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -37,7 +44,7 @@ jobs:
           tags: |
             ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:latest
             ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:${{ github.sha }}
-            ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:${{ github.event.release.tag_name }}
+            ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:${{ steps.meta.outputs.release_tag }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
@@ -64,6 +71,8 @@ jobs:
             git diff --quiet
             git diff --cached --quiet
             git fetch origin
+            # mainに含まれないcommitのreleaseはデプロイしない
+            git merge-base --is-ancestor ${{ github.sha }} origin/main
             git checkout -B main ${{ github.sha }}
             export IMAGE_TAG=${{ github.sha }}
             make deploy:prod ENV=prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 #file: noinspection YAMLSchemaValidation
 name: Deploy
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [ published ]
 concurrency:
   group: deploy
   cancel-in-progress: false
@@ -37,6 +37,7 @@ jobs:
           tags: |
             ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:latest
             ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:${{ github.sha }}
+            ghcr.io/act-kithub/kithubsys/${{ matrix.service }}:${{ github.event.release.tag_name }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 

--- a/Makefile
+++ b/Makefile
@@ -87,4 +87,4 @@ envs\:setup:
 	cp envs/db.env.example envs/db.env
 	cp envs/sentry.env.example envs/sentry.env
 
-PHONY: build up up\:ci down logs ps pull pr\:create deploy\:prod poetry\:install poetry\:add poetry\:lock poetry\:update poetry\:reset dev\:setup db\:revision\:create db\:migrate envs\:init
+.PHONY: build up up\:ci down logs ps pull pr\:create deploy\:prod poetry\:install poetry\:add poetry\:lock poetry\:update poetry\:reset dev\:setup db\:revision\:create db\:migrate envs\:init

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ build\:no-cache:
 up:
 	docker compose -f $(COMPOSE_YML) up --build -d
 
+up\:ci:
+	docker compose -f $(COMPOSE_YML) up -d --wait --wait-timeout 180
+
 down:
 	docker compose -f $(COMPOSE_YML) down
 
@@ -84,4 +87,4 @@ envs\:setup:
 	cp envs/db.env.example envs/db.env
 	cp envs/sentry.env.example envs/sentry.env
 
-PHONY: build up down logs ps pull pr\:create deploy\:prod poetry\:install poetry\:add poetry\:lock poetry\:update poetry\:reset dev\:setup db\:revision\:create db\:migrate envs\:init
+PHONY: build up up\:ci down logs ps pull pr\:create deploy\:prod poetry\:install poetry\:add poetry\:lock poetry\:update poetry\:reset dev\:setup db\:revision\:create db\:migrate envs\:init

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,5 +1,6 @@
 services:
   discord:
+    image: kithubsys-discord:dev
     build:
       context: .
       dockerfile: discord/Dockerfile
@@ -63,6 +64,7 @@ services:
       - db
 
   db-migrator:
+    image: kithubsys-db-migrator:dev
     build:
       context: .
       dockerfile: ./db/Dockerfile

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0b4-slim
+FROM python:3.12.13-slim
 
 # set workdir
 WORKDIR /app

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0b4-slim
+FROM python:3.12.13-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要

develop ブランチ廃止に伴い dependabot 設定を刷新し、デプロイのトリガーを main push から GitHub Release の公開に変更する。

## やったこと

### dependabot 設定の刷新（develop 廃止 + 規約準拠）

- `target-branch: develop` を全 entry から削除（default branch = main を使用）
- deprecated な `reviewers` キーを削除し `assignees` に集約
- docker の 2 entry（/db, /discord）を `directories` で 1 entry に統合
  - `python` イメージの major / minor 更新は ignore（pyproject の `python = "3.12.*"` 制約と整合しないため。#294 と同内容）
- version-updates を ecosystem ごとに 1 PR へグループ集約、security-updates は別グループで即時 PR
- schedule を weekly に変更し、cooldown を追加
  - pip: default 3 日 / patch 1 日
  - github-actions / docker: default 3 日のみ（semver 別 cooldown は両 ecosystem 非対応）

### デプロイの release トリガー化

- `on: push（main）` → `on: release: types: [published]` に変更
- ガードを追加
  - pre-release では build / deploy を実行しない
  - サーバー側で release の commit が origin/main に含まれることを検証（main 外 commit の release を本番に載せない）
- イメージタグに release タグ名を追加（`:latest` / `:<sha>` / `:<サニタイズ済み tag_name>`）
  - `/` 等の Docker tag 非対応文字は `-` に置換

## やらなかったこと

- pip への `/discord`・`/db` の追加（配下の pyproject / poetry.lock は root への symlink のため `/` のみで全依存をカバーできる）
- docker-compose ecosystem の追加（`compose.dev.yml` / `compose.prod.yml` というカスタムファイル名を dependabot が検出できないため。[dependabot-core#12134](https://github.com/dependabot/dependabot-core/issues/12134)）
- develop 参照が残る他ファイルの整理（Makefile の `pr:create`（`git switch develop` するため現状 broken）、check_healthy.yml の `branches: [main, develop]`、sync-template / update-pr-labels）
- main push 時のビルド検証 CI の追加（release まで build 失敗に気づけない構造への手当て）

## 影響範囲

- dependabot の PR 作成先・頻度・粒度（daily 個別 PR → weekly グループ PR）
- デプロイの実行タイミング（main push 時 → release 公開時。**マージ後は release を公開しない限りデプロイされない**）

## テスト方法

- dependabot.yml: YAML parse 通過・directory 実在・cooldown の ecosystem 別対応を公式 docs で確認済み
- deploy.yml: actionlint 通過、tag サニタイズはローカルで動作確認済み
- マージ後、release を 1 件公開して build → deploy の成功を確認

## チェックリスト

- [x] YAML parse / actionlint 通過
- [ ] マージ後の初回 release でデプロイ成功確認

## 補足

- #294（ビルド失敗の修正）と dependabot.yml が競合する。**#294 を先にマージ**してもらえれば、本 PR を rebase して解消する（本 PR の dependabot.yml は #294 の ignore 設定を織り込み済み）

https://claude.ai/code/session_01QAJGNVYDiLgpVXjSEiTg9Q